### PR TITLE
Fix: Update actor sheet templates for dnd5e 4.3 data paths

### DIFF
--- a/module.json
+++ b/module.json
@@ -43,8 +43,8 @@
 				"type": "system",
 				"compatibility": {
 					"minimum": "3.3.0",
-					"verified": "3.3.1",
-					"maximum": "4"
+					"verified": "4.3.6",
+					"maximum": "4.3.6"
 				}
 			}
 		]

--- a/scripts/modules/actor.js
+++ b/scripts/modules/actor.js
@@ -29,11 +29,15 @@ export class ActorSyb5e {
 				value: ActorSyb5e.prepareDerivedData,
 				mode: 'WRAPPER',
 			},
+			// LIBWRAPPER_TARGET: dnd5e.documents.Actor5e.prototype.longRest
 			longRest: {
 				value: ActorSyb5e.longRest,
+				mode: 'WRAPPER', // Added mode: 'WRAPPER'
 			},
+			// LIBWRAPPER_TARGET: dnd5e.documents.Actor5e.prototype.shortRest
 			shortRest: {
 				value: ActorSyb5e.shortRest,
+				mode: 'WRAPPER', // Added mode: 'WRAPPER'
 			},
 			convertSybCurrency: {
 				value: ActorSyb5e.convertSybCurrency,
@@ -61,6 +65,9 @@ export class ActorSyb5e {
 			},
 		};
 
+		// LIBWRAPPER_TARGET: Patches for dnd5e.documents.Actor5e.prototype are registered below.
+		// Targets include: getRollData, prepareBaseData, prepareDerivedData, longRest, shortRest.
+		// Other properties are effectively new additions or direct overrides if they happen to exist.
 		COMMON.patch(target, targetPath, patches);
 	}
 
@@ -280,6 +287,7 @@ export class ActorSyb5e {
 				return 0;
 			case 'spellcasting': {
 				/* if corruption is set to use spellcasting, ensure we have a spellcasting stat as well */
+				// DND5E_COMPATIBILITY: actor.system.attributes.spellcasting is the key for the primary spellcasting ability.
 				corruptionAbility = !!actor.system.attributes.spellcasting ? corruptionAbility : defaultAbility;
 			}
 		}
@@ -287,15 +295,21 @@ export class ActorSyb5e {
 		const usesSpellcasting = corruptionAbility === 'spellcasting';
 
 		/* otherwise determine corruption calc -- full casters get a special one */
+		// DND5E_COMPATIBILITY: actor.classes is used to determine character's spellcasting progression.
+		// DND5E_COMPATIBILITY: actor.system (specifically actor.system.details.spellLevel for NPCs) is used.
+		// Relies on Spellcasting._maxSpellLevelByClass and Spellcasting._maxSpellLevelNPC from spellcasting.js.
 		const { fullCaster } =
 			actor.type === 'character' ? Spellcasting._maxSpellLevelByClass(Object.values(actor.classes)) : Spellcasting._maxSpellLevelNPC(actor.system);
 
+		// DND5E_COMPATIBILITY: actor.system.attributes.prof is the proficiency bonus.
 		const prof = actor.system.attributes.prof ?? currentMax;
 		if (prof == null) {
 			logger.error('SYB5E.Error.NoProf');
 		}
 
+		// DND5E_COMPATIBILITY: actor.system.attributes.spellcasting (if used) or a specific ability key.
 		const corrAbility = usesSpellcasting ? actor.system.attributes.spellcasting : corruptionAbility;
+		// DND5E_COMPATIBILITY: actor.system.abilities[abilityKey].mod is the ability modifier.
 		const corrMod = actor.system.abilities[corrAbility].mod ?? 0;
 
 		/* we can only apply a bonus to an automatically computed maximum (i.e. derived from attributes) */

--- a/scripts/modules/item-sheet.js
+++ b/scripts/modules/item-sheet.js
@@ -33,12 +33,14 @@ export class Syb5eItemSheet {
 		}
 
 		/* only concerned with adding favored to sybactor owned spell type items */
+		// DND5E_COMPATIBILITY: Accessing item.type.
 		if (item.type == 'spell') {
 			const data = {
 				...commonData,
+				// Uses custom getter ItemSyb5e.isFavored
 				isFavored: item.isFavored,
-				favoredPath: SYB5E.CONFIG.PATHS.favored,
-				favoredValue: foundry.utils.getProperty(item, SYB5E.CONFIG.PATHS.favored) ?? 0,
+				favoredPath: SYB5E.CONFIG.PATHS.favored, // Module-specific path
+				favoredValue: foundry.utils.getProperty(item, SYB5E.CONFIG.PATHS.favored) ?? 0, // Module-specific path
 				favoredStates: {
 					[COMMON.localize('SYB5E.Spell.Favored')]: 1,
 					[COMMON.localize('SYB5E.Spell.NotFavored')]: 0,
@@ -50,18 +52,25 @@ export class Syb5eItemSheet {
 			const favoredBadge = await renderTemplate(`${COMMON.DATA.path}/templates/items/parts/spell-favored-badge.html`, data);
 
 			/* adjust spell prep div style to <label style="max-width: fit-content;"> */
+			// DND5E_SHEET_DOM: Targets 'label.checkbox.prepared', specific to dnd5e spell preparation.
 			const preparedCheckbox = html.find('label.checkbox.prepared');
+			// DND5E_SHEET_DOM: DOM traversal (parent(), prev()) is fragile.
 			const prepModeLineLabel = preparedCheckbox.parent().prev();
 			prepModeLineLabel.css('max-width', 'fit-content');
 
 			/* insert our favored select menu */
+			// DND5E_SHEET_DOM: Injecting HTML after the prepared checkbox.
 			preparedCheckbox.after(favoredSelect);
 
 			/* insert our favored badge */
+			// DND5E_SHEET_DOM: Targets '.properties-list li', dnd5e specific structure.
 			const itemPropBadges = html.find('.properties-list li');
+			// DND5E_SHEET_DOM: Injecting HTML after the last property badge.
 			itemPropBadges.last().after(favoredBadge);
 
 			/* find the "Cost (GP)" label (if it exists) */
+			// DND5E_SHEET_DOM: Targets label before input with name="system.materials.cost".
+			// DND5E_COMPATIBILITY: Relies on item.system.materials.cost structure.
 			const costLabel = html.find('[name="system.materials.cost"]').prev();
 			if (costLabel.length > 0) {
 				costLabel.text(COMMON.localize('SYB5E.Currency.CostThaler'));
@@ -69,8 +78,10 @@ export class Syb5eItemSheet {
 		}
 
 		/* need to rename "subclass" to "approach" */
+		// DND5E_COMPATIBILITY: Accessing item.type.
 		if (item.type == 'subclass') {
 			/* get the subclass text field entry */
+			// DND5E_SHEET_DOM: Targets '.header-details .item-type', dnd5e specific.
 			const subclassLabel = html.find('.header-details .item-type');
 			if (subclassLabel.length > 0) {
 				subclassLabel.text(COMMON.localize('SYB5E.Item.Class.Approach'));
@@ -79,7 +90,8 @@ export class Syb5eItemSheet {
 			}
 
 			/* remove spellcasting progression not in syb5e */
-			const filterList = Object.keys(game.syb5e.CONFIG.SPELL_PROGRESSION).reduce((acc, key) => {
+			// DND5E_COMPATIBILITY: Relies on item.system.spellcasting.progression structure and values.
+			const filterList = Object.keys(game.syb5e.CONFIG.SPELL_PROGRESSION).reduce((acc, key) => { // Module-specific config
 				if (acc.length == 0) {
 					/* dont put the comma in front */
 					acc += `[value="${key}"]`;
@@ -88,13 +100,17 @@ export class Syb5eItemSheet {
 				}
 				return acc;
 			}, '');
+			// DND5E_SHEET_DOM: Targets select with name="system.spellcasting.progression".
 			const progressionSelect = html.find('[name="system.spellcasting.progression"]');
+			// DND5E_SHEET_DOM: Removing options from a select element.
 			progressionSelect.children().not(filterList).remove();
 		}
 
 		/* we want to add a custom corruption field if there is a general resource consumption field */
+		// DND5E_SHEET_DOM: Targets '.form-group.consumption', dnd5e specific.
 		const consumeGroup = html.find('.form-group.consumption');
 		if (consumeGroup.length > 0) {
+			// Uses custom getter ItemSyb5e.corruptionOverride
 			const currentOverrides = item.corruptionOverride;
 			let data = {
 				corruptionType: {

--- a/scripts/modules/item.js
+++ b/scripts/modules/item.js
@@ -46,6 +46,9 @@ export class ItemSyb5e {
 			},
 		};
 
+		// LIBWRAPPER_TARGET: Patches for dnd5e.documents.Item5e.prototype are registered below.
+		// Targets include: properties (getter override), getRollData (wrapper), hasDamage (wrapper).
+		// Other properties (corruption, corruptionOverride, isFavored) are new custom getters.
 		COMMON.patch(target, targetPath, patches);
 	}
 
@@ -66,12 +69,14 @@ export class ItemSyb5e {
 	}
 
 	static getProperties() {
+		// DND5E_COMPATIBILITY: Accessing item.system.properties.
 		let props = this.system.properties ?? {};
 		/* Armor will also have item properties similar to Weapons */
 
 		/* is armor type? return syb armor props or the default object
 		 * if no flag data exists yet */
 		if (this.isArmor) {
+			// FOUNDRY_API: Accessing item flags via this.getFlag().
 			return foundry.utils.mergeObject(props, this.getFlag(COMMON.DATA.name, 'armorProps') ?? game.syb5e.CONFIG.DEFAULT_ITEM.armorProps);
 		}
 
@@ -171,10 +176,14 @@ export class ItemSyb5e {
     const corruption = foundry.utils.getProperty(message, game.syb5e.CONFIG.PATHS.corruption.root + '.last') ?? {};
 
     /* Do not re-eval previously rolled corruption values */
+    // FOUNDRY_CHAT_DOM: This method directly manipulates the chat message HTML (html parameter).
+    // Its robustness depends on the stability of the chat message structure.
     if ( message.author.isSelf 
       && ('expression' in corruption)
       && !('total' in corruption)) {
 
+      // DND5E_COMPATIBILITY: Accessing message.getFlag('dnd5e', 'use') to get item UUID.
+      // This flag structure is specific to how dnd5e handles item usage in chat messages.
       const {itemUuid = null} = message.getFlag('dnd5e','use'); 
       const item = await fromUuid(itemUuid);
       const actor = item.actor;
@@ -231,7 +240,7 @@ export class ItemSyb5e {
     <span class="roll-result">${corruption.total}</span>
   </p>
 </div>`;
-
+      // FOUNDRY_CHAT_DOM: Injecting custom HTML content into the chat message.
       html.insertAdjacentHTML('beforeend', corruptionContent);
     }
   

--- a/templates/actors/syb5e-character-sheet.html
+++ b/templates/actors/syb5e-character-sheet.html
@@ -104,7 +104,7 @@
                         <span>{{system.attributes.ac.value}}</span>
                     </div>
                     <footer class="attribute-footer">
-                        <span class="spell-dc">{{localize "DND5E.SpellDC"}} {{system.attributes.spelldc}}</span>
+                        <span class="spell-dc">{{localize "DND5E.SpellDC"}} {{system.attributes.spell.dc}}</span>
                     </footer>
                 </li>
 
@@ -168,7 +168,7 @@
                             {{{ability.icon}}}
                         </a>
                         <span class="ability-save" data-tooltip="DND5E.SavingThrow">
-                            {{numberFormat ability.save decimals=0 sign=true}}
+                            {{numberFormat ability.save.value decimals=0 sign=true}}
                         </span>
                     </div>
                     <a class="config-button" data-action="ability"

--- a/templates/actors/syb5e-npc-sheet.html
+++ b/templates/actors/syb5e-npc-sheet.html
@@ -140,7 +140,7 @@
                             {{{ability.icon}}}
                         </a>
                         <span class="ability-save" data-tooltip="DND5E.SavingThrow">
-                            {{numberFormat ability.save decimals=0 sign=true}}
+                            {{numberFormat ability.save.value decimals=0 sign=true}}
                         </span>
                     </div>
                     <a class="config-button" data-action="ability"


### PR DESCRIPTION
This commit addresses errors caused by changes in dnd5e 4.3.0 data structures:

- Replaced references to `system.attributes.spelldc` with the correct `system.attributes.spell.dc` in actor sheet templates.
- Updated actor sheet templates to use `system.abilities.<ability>.save.value` when displaying numerical saving throw values, instead of the old `system.abilities.<ability>.save`.

These changes resolve compatibility warnings and errors related to `spelldc` and saving throw display that occurred after updating to dnd5e 4.3.x.