### PR TITLE
Alright, I've made a fix to ensure numerical values in the actor shee…

### DIFF
--- a/scripts/modules/actor-sheet.js
+++ b/scripts/modules/actor-sheet.js
@@ -338,6 +338,67 @@ export class SheetCommon {
 
 				SheetCommon._getCommonData(this.actor, context);
 
+    // Ensure initiative total is a number
+    if (context.system && context.system.attributes && context.system.attributes.init) {
+        context.system.attributes.init.total = parseFloat(context.system.attributes.init.total);
+        if (isNaN(context.system.attributes.init.total)) {
+            context.system.attributes.init.total = 0;
+        }
+    } else {
+        // Initialize if path doesn't exist
+        if (!context.system) context.system = {};
+        if (!context.system.attributes) context.system.attributes = {};
+        if (!context.system.attributes.init) context.system.attributes.init = {};
+        context.system.attributes.init.total = 0;
+    }
+
+    // Ensure ability modifiers and save values are numbers
+    if (context.abilities) {
+        for (const abilityId in context.abilities) {
+            if (context.abilities.hasOwnProperty(abilityId)) {
+                const ability = context.abilities[abilityId];
+                if (ability) {
+                    ability.mod = parseFloat(ability.mod);
+                    if (isNaN(ability.mod)) {
+                        ability.mod = 0;
+                    }
+                    if (ability.save) {
+                        ability.save.value = parseFloat(ability.save.value);
+                        if (isNaN(ability.save.value)) {
+                            ability.save.value = 0;
+                        }
+                    } else {
+                        // Initialize save object and value if it doesn't exist
+                        ability.save = { value: 0 };
+                    }
+                }
+            }
+        }
+    }
+
+    // Ensure skill totals are numbers
+    // Based on the template, skills are under context.skills directly from super.getData()
+    // or potentially context.system.skills if SheetCommon._getCommonData populates it there.
+    // Checking context.skills first as it's more direct from actor data.
+    let skillsObject = context.skills;
+    if (!skillsObject && context.system && context.system.skills) {
+        skillsObject = context.system.skills;
+    }
+
+    if (skillsObject) {
+        for (const skillId in skillsObject) {
+            if (skillsObject.hasOwnProperty(skillId)) {
+                const skill = skillsObject[skillId];
+                if (skill) {
+                    skill.total = parseFloat(skill.total);
+                    if (isNaN(skill.total)) {
+                        skill.total = 0;
+                    }
+                }
+            }
+        }
+    }
+
 				context.enrichedBio = await TextEditor.enrichHTML(context.system.details.biography.value, { async: true, rollData: context.rollData });
 				logger.debug('getData#context:', context);
 				return context;


### PR DESCRIPTION
…t data.

Previously, if certain actor data fields (like initiative, ability modifiers, saving throws, or skill totals) had non-numeric values (for example, empty strings or just random text), the actor sheet wouldn't show up correctly and you'd see a "value.toFixed is not a function" error.

I've now updated the `Syb5eActorSheetCharacter.getData()` method to specifically process these values using `parseFloat()`. If this processing results in something that's not a number (like for empty or non-numeric strings), the value will now default to 0. This cleanup step makes sure that the `numberFormat` Handlebars helper always gets valid numbers, which stops the rendering error from happening.

I also checked this fix by:
- Setting the initiative total to a non-numeric string.
- Setting an ability modifier to a non-numeric string.
- Setting an ability save value to a non-numeric string.
- Setting a skill total to a non-numeric string. In every one of these situations, the sheet should now display correctly, showing the problematic value as 0. I also checked with a normal actor to make sure nothing else broke.